### PR TITLE
Dostosowanie do pythona 3

### DIFF
--- a/Z-15.py
+++ b/Z-15.py
@@ -95,7 +95,7 @@ def other_parent_took_care(parent):
     days_gt14 = 0
 
     f = u'topmostSubform[0].Page3[0].WybórTAKNIE3[0]'
-    if leaves_this_year(parent['leaves']) <= 0:
+    if len(leaves_this_year(parent['leaves'])) <= 0:
         fields.append((f, FDFFalse))
         return fields
 

--- a/Z-15.py
+++ b/Z-15.py
@@ -37,7 +37,7 @@ class DateArgAction(argparse.Action):
     #     super(FooAction, self).__init__(option_strings, dest, **kwargs)
     def __call__(self, parser, namespace, values, option_string=None):
         _date = dateutil.parser.parse(values)
-        print '%r %r %r' % (namespace, values, option_string)
+        print('{} {} {}'.format(namespace, values, option_string))
         setattr(namespace, self.dest, _date)
 
 parser = argparse.ArgumentParser(
@@ -108,8 +108,8 @@ def other_parent_took_care(parent):
         _d = pesel_data(_c['id'])
         _age14 = datetime.date(_d.year + 14, _d.month, _d.day)
         if _s < _age14:
-            print "_s:" + _s.strftime("%Y-%m-%d")
-            print "_u:" + _u.strftime("%Y-%m-%d")
+            print("_s: {}".format(_s.strftime("%Y-%m-%d")))
+            print("_u: {}".format(_u.strftime("%Y-%m-%d")))
             days_lt14 += (_u - _s).days + 1
         else:
             days_gt14 += (_u - _s).days

--- a/Z-15.yaml.example
+++ b/Z-15.yaml.example
@@ -66,7 +66,9 @@ PARENTS:
     first_name: Janina
     parent: matka
     other_parent: jan
+    address: home
     employer: biuro
+    bank_account: "XXXXXXXXXXXXXXXXXXXXXXXXXX"
     leaves:
       - since: 2017-01-23
         until: 2017-01-27

--- a/pesel.py
+++ b/pesel.py
@@ -57,7 +57,7 @@ def pesel_data(nrid):
     '''Podaje datê urodzenia na podstawie PESELu o ile jest poprawny'''
     if pesel_ok(nrid):
         d,m,r=int(nrid[4:6]),int(nrid[2:4]),int(nrid[0:2])
-        r,m=(m>80)*1800+(m<80)*(1900+(m/20)*100)+r,m%20
+        r,m=int((m>80)*1800+(m<80)*(1900+(m/20)*100)+r),int(m%20)
         if m in range(1,13):
             return datetime.date(r,m,d)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fdfgen
+pyyaml


### PR DESCRIPTION
Po zmianach działa. Można jeszcze kilka rzeczy zmienić (np. u'...' jest niepotrzebne), ale to co wrzucam to są minimalne zmiany, które powodują, że na pythonie trójce chodzi jak powinno.
Nie wiem czy sprawdzanie leaves_this_year() działało w takiej formie na python2. Na 3 w każdym razie nie działa i wygląda to na przeoczenie.